### PR TITLE
Fixed method-index bug

### DIFF
--- a/src/parser/parse_data.rs
+++ b/src/parser/parse_data.rs
@@ -364,7 +364,7 @@ fn transform_encoded_methods<'a>(data: &'a[u8], data_off: usize, raw: &[RawEncod
             code
         });
 
-        prev_offset = method.method_idx_diff;
+        prev_offset += method.method_idx_diff;
     }
 
     Ok((data, methods))


### PR DESCRIPTION
This fixes #2 
All tests pass and it correctly indexes the methods in the dex-files I've tried.